### PR TITLE
fixed casa6 Dockerfile

### DIFF
--- a/cultcargo/builder/cargo-manifest.yml
+++ b/cultcargo/builder/cargo-manifest.yml
@@ -73,7 +73,9 @@ images:
   casa6:
     versions:
       '6.5':
-          wheel_version: 6.5.5.20
+          wheel_version: 6.5.6.22
+      '6.6':
+          wheel_version: 6.6.3.22
 
   breizorro:
     versions:

--- a/cultcargo/images/casa6/Dockerfile
+++ b/cultcargo/images/casa6/Dockerfile
@@ -1,6 +1,6 @@
 FROM {REGISTRY}/base-cult:{BUNDLE_VERSION}
 
-RUN pip install --no-cache-dir casatools=={wheel_version} casatasks=={wheel_version} casadata=={wheel_version}
+RUN pip install --no-cache-dir casatools=={wheel_version} casatasks=={wheel_version} casadata
 
 CMD /usr/bin/python3.8
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cult-cargo"
-version = "0.1.2rc6"
+version = "0.1.2rc7"
 description = "Curated cargo of standard radio astronomy packages for stimela 2.0"
 authors = ["Oleg Smirnov, Sphesihle Makhathini"]
 license = "MIT"


### PR DESCRIPTION
@SpheMakh we made a booboo in #27, the casa6 Dockerfile was broken, as casadata doesn't use the same versioning scheme as casatools and casatasks.

Next time please run e.g. ``build-cargo casa6`` to verify (and push) the updated image. I do mean to write up a "cult-cargo update workflow" very soon where I'll document these details.

But just as well I had to redo this -- I saw the casa6 6.5.x release we were installing had been yanked.
