### PR TITLE
WSCLEAN `temp-dir` parameter updates

### DIFF
--- a/cultcargo/genesis/wsclean/wsclean-base.yml
+++ b/cultcargo/genesis/wsclean/wsclean-base.yml
@@ -14,7 +14,6 @@ lib:
           dtype: str
           nom_de_guerre: name
           required: true
-          mkdir: true
         column:
           dtype: str
           nom_de_guerre: data-column

--- a/cultcargo/genesis/wsclean/wsclean-base.yml
+++ b/cultcargo/genesis/wsclean/wsclean-base.yml
@@ -136,10 +136,6 @@ lib:
           dtype:  bool
         use-wgridder:
           dtype: bool
-        temp-dir:
-          dtype: Directory
-          skip_freshness_checks: true
-          writable: true
         log-time:
           dtype: bool
         interval:
@@ -170,4 +166,10 @@ lib:
           info: Source list
           dtype: File
           implicit: "{current.prefix}-sources.txt"
+          must_exist: false
+        temp-dir:
+          dtype: Directory
+          skip_freshness_checks: true
+          writable: true
+          mkdir: true
           must_exist: false

--- a/cultcargo/genesis/wsclean/wsclean-base.yml
+++ b/cultcargo/genesis/wsclean/wsclean-base.yml
@@ -169,6 +169,5 @@ lib:
         temp-dir:
           dtype: Directory
           skip_freshness_checks: true
-          writable: true
           mkdir: true
           must_exist: false


### PR DESCRIPTION
As reported by @landmanbester on the lightcurve pipeline repo, the current specification of the `temp-dir` parameter will not create one it if it does not exist. This PR addresses this issue by making the `temp-dir` an output. Outputs support `mkdir`. Additionally, this PR removes `mkdir` the non-output `prefix` parameter as it is not necessary. 