### PR TITLE
Change output image handling when `no-dirty` is specified.

### DIFF
--- a/cultcargo/genesis/wsclean/__init__.py
+++ b/cultcargo/genesis/wsclean/__init__.py
@@ -48,7 +48,9 @@ def make_stimela_schema(params: Dict[str, Any], inputs: Dict[str, Parameter], ou
     multitime = params.get('multi.intervals', not isinstance(ntime, int) or ntime > 1)
 
     for imagetype in "dirty", "restored", "residual", "model":
-        if imagetype == "dirty" or params.get('niter', 0) > 0:
+        if imagetype == "dirty" and not params.get("no-dirty", False):
+            must_exist = True
+        elif params.get('niter', 0) > 0:
             must_exist = True
         else:
             must_exist = False

--- a/cultcargo/genesis/wsclean/__init__.py
+++ b/cultcargo/genesis/wsclean/__init__.py
@@ -50,7 +50,7 @@ def make_stimela_schema(params: Dict[str, Any], inputs: Dict[str, Parameter], ou
     for imagetype in "dirty", "restored", "residual", "model":
         if imagetype == "dirty" and not params.get("no-dirty", False):
             must_exist = True
-        elif params.get('niter', 0) > 0:
+        elif imagetype != "dirty" and params.get('niter', 0) > 0:
             must_exist = True
         else:
             must_exist = False


### PR DESCRIPTION
Currently, wsclean outputs presume the existence of dirty images. This may not be the case if the user has specified `no-dirty` in their config. This tiny fix should stop stimela from complaining about missing dirty images. 