### PR TITLE
modified no-dirty case, redux

### DIFF
--- a/cultcargo/genesis/wsclean/__init__.py
+++ b/cultcargo/genesis/wsclean/__init__.py
@@ -48,9 +48,10 @@ def make_stimela_schema(params: Dict[str, Any], inputs: Dict[str, Parameter], ou
     multitime = params.get('multi.intervals', not isinstance(ntime, int) or ntime > 1)
 
     for imagetype in "dirty", "restored", "residual", "model":
-        if imagetype == "dirty" and not params.get("no-dirty", False):
-            must_exist = True
-        elif imagetype != "dirty" and params.get('niter', 0) > 0:
+        if imagetype == "dirty":
+            if params.get("no-dirty", False):
+                continue
+        elif imagetype == 'restored' or params.get('niter', 0) > 0:
             must_exist = True
         else:
             must_exist = False

--- a/cultcargo/genesis/wsclean/__init__.py
+++ b/cultcargo/genesis/wsclean/__init__.py
@@ -51,6 +51,7 @@ def make_stimela_schema(params: Dict[str, Any], inputs: Dict[str, Parameter], ou
         if imagetype == "dirty":
             if params.get("no-dirty", False):
                 continue
+            must_exist = True
         elif imagetype == 'restored' or params.get('niter', 0) > 0:
             must_exist = True
         else:


### PR DESCRIPTION
I think ``dirty`` should be omitted from the schema entirely if ``no-dirty`` is in effect.

``restored`` should be a must-exist even when niter=0.