### PR TITLE
change channel-range policy to list

### DIFF
--- a/cultcargo/genesis/wsclean/wsclean-base.yml
+++ b/cultcargo/genesis/wsclean/wsclean-base.yml
@@ -1,5 +1,5 @@
 lib:
-  params: 
+  params:
     wsclean:
       base-inputs:
         ms:
@@ -28,7 +28,7 @@ lib:
         channel-range:
           dtype: List[int]
           policies:
-            repeat: ' '
+            repeat: list
         pol:
           dtype: Union[str, List[str]]
           element_choices: [I,Q,U,V,QU,QUV,IQ,IV,IQU,IQUV,XX,XY,YX,YY,LL,LR,RL,RR]


### PR DESCRIPTION
The cab used to fail with the `channel-range` parameter defined as
```yaml
channel-range:
    dtype: List[int]
    policies:
      repeat: ' '
```
Changing the repeat policy to `repeat: list` fixes the problem