### PR TITLE
Allow temporary versioning from the CLI in `build-cargo`

### DIFF
--- a/cultcargo/builder/build_cargo.py
+++ b/cultcargo/builder/build_cargo.py
@@ -72,7 +72,7 @@ print = console.print
 @click.option('-a', '--all', is_flag=True, help='Build and/or push all images in manifest.')
 @click.option('-E', '--experimental', is_flag=True, help='Enable experimental versions.')
 @click.option('-v', '--verbose', is_flag=True, help='Be verbose.')
-@click.option('-iv', '--imageversion', nargs=3, multiple=True, type=str, help='Build image as specific version. Syntax is -iv image version.')
+@click.option('-iv', '--imageversion', nargs=3, multiple=True, type=str, help='Build image as specific version. Syntax is -iv image version dockerfile')
 @click.option('--boring', is_flag=True, help='Be boring -- no progress bar.')
 @click.argument('imagenames', type=str, nargs=-1)
 def build_cargo(manifest: str, do_list=False, build=False, push=False, all=False, rebuild=False, boring=False,

--- a/cultcargo/builder/build_cargo.py
+++ b/cultcargo/builder/build_cargo.py
@@ -191,6 +191,7 @@ def build_cargo(manifest: str, do_list=False, build=False, push=False, all=False
 
         tag_latest = {}
         for image, image_info in conf.images.items():
+            print(image_info)
             versions = list(image_info.versions.keys())
             if not versions:
                 print(f"No versions defined for {image}")

--- a/cultcargo/builder/build_cargo.py
+++ b/cultcargo/builder/build_cargo.py
@@ -184,7 +184,7 @@ def build_cargo(manifest: str, do_list=False, build=False, push=False, all=False
         # dict below is populated with the versions that need to be tagged.
 
         if imageversion:
-            dynamic_version = dict(image_version)
+            dynamic_version = dict(imageversion)
             print(dynamic_version)
         else:
             dynamic_version = {}

--- a/cultcargo/builder/build_cargo.py
+++ b/cultcargo/builder/build_cargo.py
@@ -71,10 +71,11 @@ print = console.print
 @click.option('-a', '--all', is_flag=True, help='Build and/or push all images in manifest.')
 @click.option('-E', '--experimental', is_flag=True, help='Enable experimental versions.')
 @click.option('-v', '--verbose', is_flag=True, help='Be verbose.')
+@click.option('-iv', '--imageversion', nargs=2, multiple=True, type=str, help='Build image as specific version. Syntax is -iv image version.')
 @click.option('--boring', is_flag=True, help='Be boring -- no progress bar.')
 @click.argument('imagenames', type=str, nargs=-1)
 def build_cargo(manifest: str, do_list=False, build=False, push=False, all=False, rebuild=False, boring=False,
-                experimental=False, verbose=False, imagenames: List[str] = []):
+                experimental=False, verbose=False, imageversion=None, imagenames: List[str] = []):
     if not (build or push or do_list):
         build = push = True
 
@@ -181,6 +182,13 @@ def build_cargo(manifest: str, do_list=False, build=False, push=False, all=False
         # (c) The last version listed is tagged as latest.
         # In cases (b) and (c), an additional tag operation needs to be done, so the tag_latest
         # dict below is populated with the versions that need to be tagged.
+
+        if imageversion:
+            dynamic_version = dict(image_version)
+            print(dynamic_version)
+        else:
+            dynamic_version = {}
+
         tag_latest = {}
         for image, image_info in conf.images.items():
             versions = list(image_info.versions.keys())

--- a/cultcargo/builder/build_cargo.py
+++ b/cultcargo/builder/build_cargo.py
@@ -72,11 +72,12 @@ print = console.print
 @click.option('-a', '--all', is_flag=True, help='Build and/or push all images in manifest.')
 @click.option('-E', '--experimental', is_flag=True, help='Enable experimental versions.')
 @click.option('-v', '--verbose', is_flag=True, help='Be verbose.')
-@click.option('-iv', '--imageversion', nargs=3, multiple=True, type=str, help='Build image as specific version. Syntax is -iv image version dockerfile')
+@click.option('-ev', '--extraversion', nargs=3, multiple=True, type=str,
+              help='Build an image with additional versions. Syntax is -ev image version dockerfile. Can be specified multiple times.')
 @click.option('--boring', is_flag=True, help='Be boring -- no progress bar.')
 @click.argument('imagenames', type=str, nargs=-1)
 def build_cargo(manifest: str, do_list=False, build=False, push=False, all=False, rebuild=False, boring=False,
-                experimental=False, verbose=False, imageversion=None, imagenames: List[str] = []):
+                experimental=False, verbose=False, extraversion=None, imagenames: List[str] = []):
     if not (build or push or do_list):
         build = push = True
 
@@ -184,8 +185,9 @@ def build_cargo(manifest: str, do_list=False, build=False, push=False, all=False
         # In cases (b) and (c), an additional tag operation needs to be done, so the tag_latest
         # dict below is populated with the versions that need to be tagged.
 
+        # Turn version specified via the CLI into a dict per image.
         extra_versions = defaultdict(dict)    
-        for image, version, dockerfile in imageversion:
+        for image, version, dockerfile in extraversion:
             extra_versions[image][version] = dict(dockerfile=dockerfile)
 
         tag_latest = {}

--- a/cultcargo/builder/build_cargo.py
+++ b/cultcargo/builder/build_cargo.py
@@ -187,11 +187,9 @@ def build_cargo(manifest: str, do_list=False, build=False, push=False, all=False
         extra_versions = defaultdict(dict)    
         for image, version, dockerfile in imageversion:
             extra_versions[image][version] = dict(dockerfile=dockerfile)
-        print(extra_versions)
 
         tag_latest = {}
         for image, image_info in conf.images.items():
-            print(image_info)
             versions = list(image_info.versions.keys())
             if not versions:
                 print(f"No versions defined for {image}")
@@ -210,8 +208,9 @@ def build_cargo(manifest: str, do_list=False, build=False, push=False, all=False
             elif "latest" not in versions:
                 tag_latest[image] = f"{versions[-1]}-{BUNDLE_VERSION}"  # case (c)
 
+            # NOTE(JSKenyon): We don't want dynamically added versions to mess
+            # with the assignment of the latest tag.
             conf.images[image]["versions"].update(extra_versions[image])
-            print(image_info)
 
         no_cache = "--no-cache" if rebuild else ""
 


### PR DESCRIPTION
@o-smirnov I took a very rudimentary stab at this myself. This may not be a good idea though. At present this doesn't add a selection mechanism, it just provides a way to to specify extra versioning from the CLI. This would look something like this:
```bash
build-cargo -m manifest.yml -a --extraversion image branch dockerfile
```

This allows CI to create versions for each branch without needing to add fields for each one. I have already tested this out on the `breifast` repo. If you have a more elegant solution, I would be happy to look over or even try implementing it. 