### PR TITLE
Use environment variables and substitutions to dynamically build from branches

### DIFF
--- a/cultcargo/builder/build_cargo.py
+++ b/cultcargo/builder/build_cargo.py
@@ -71,10 +71,11 @@ print = console.print
 @click.option('-a', '--all', is_flag=True, help='Build and/or push all images in manifest.')
 @click.option('-E', '--experimental', is_flag=True, help='Enable experimental versions.')
 @click.option('-v', '--verbose', is_flag=True, help='Be verbose.')
+@click.option('--ignore-latest-tag', is_flag=True, help='Neither require nor apply latest tag.')
 @click.option('--boring', is_flag=True, help='Be boring -- no progress bar.')
 @click.argument('imagenames', type=str, nargs=-1)
 def build_cargo(manifest: str, do_list=False, build=False, push=False, all=False, rebuild=False, boring=False,
-                experimental=False, verbose=False, imagenames: List[str] = []):
+                experimental=False, ignore_latest_tag=False, verbose=False, imagenames: List[str] = []):
     if not (build or push or do_list):
         build = push = True
 
@@ -190,7 +191,9 @@ def build_cargo(manifest: str, do_list=False, build=False, push=False, all=False
             # figure out latest version - this will be tagged as BUNDLE_VERSION
             # explicitly specified?
             latest = image_info.latest
-            if latest: # case (a)
+            if ignore_latest_tag:  # Skip latest tag logic.
+                tag_latest[image] = None
+            elif latest: # case (a)
                 if "latest" in versions:
                     print(f"Image {image}: both 'latest' version and a latest tag defined, can't have both")
                     sys.exit(1)
@@ -252,7 +255,6 @@ def build_cargo(manifest: str, do_list=False, build=False, push=False, all=False
                     f"version [bold]{version}[/bold] [{i_version}/{len(versions)}]")
 
                 # NOTE(JSKenyon): Grab version info using unformatted key.
-                # This is a little bit dodgy but the alternative is messy.
                 version_info = image_info.versions[version]
 
                 if version == "latest":


### PR DESCRIPTION
Following discussion with @o-smirnov, here is my WIP on using environment variables and substitutions to make per branch images. There are still issues at present:

- The builder assumes that the `latest` tag must be assigned, and that the version in points to must exist. I think that it may be better to assume that there is no `latest` tag, and only act when it is explicitly given. The current logic for assigning the `latest` tag can definitely result in unintended images being tagged as `latest`.
- The substitutions don't currently get propagated into `image_info.versions`. This makes things a little tricky as the version key changes as the builder progresses. My current approach just used the unsubstituted key but that seems a little dodgy.