### PR TITLE
Move casa6 to python3.10. Fixes #67

### DIFF
--- a/cultcargo/casa/bandpass.yml
+++ b/cultcargo/casa/bandpass.yml
@@ -7,12 +7,7 @@ cabs:
     casa.bandpass:
         info: Summarize dataset 
         command: casatasks.bandpass
-        flavour:
-            kind: python
-            interpreter_binary: python3.8
-        image: 
-            _use: vars.cult-cargo.images
-            name: casa6
+        _use: lib.misc.casa6.command-data
         inputs:
             _use: lib.params.casa.ms-field-spw-inputs
             caltable:

--- a/cultcargo/casa/calibration.yml
+++ b/cultcargo/casa/calibration.yml
@@ -7,12 +7,7 @@ cabs:
     casa.applycal:
         info: Summarize dataset 
         command: casatasks.applycal
-        flavour:
-            kind: python
-            interpreter_binary: python3.8
-        image: 
-            _use: vars.cult-cargo.images
-            name: casa6
+        _use: lib.misc.casa6.command-data
         inputs:
             _use: lib.params.casa.ms-field-spw-inputs
             intent:
@@ -93,12 +88,7 @@ cabs:
     casa.fluxscale:
         info: Bootstrap the flux density scale from standard calibrators 
         command: casatasks.fluxscale
-        flavour:
-            kind: python
-            interpreter_binary: python3.8
-        image: 
-            _use: vars.cult-cargo.images
-            name: casa6
+        _use: lib.misc.casa6.command-data
         inputs:
             _use: lib.params.casa.base-inputs
             caltable:
@@ -162,12 +152,7 @@ cabs:
     casa.gaincal:
         info: Uses CASA flux density calibration 
         command: casatasks.gaincal
-        flavour:
-            kind: python
-            interpreter_binary: python3.8
-        image: 
-            _use: vars.cult-cargo.images
-            name: casa6
+        _use: lib.misc.casa6.command-data
         inputs:
             _use: lib.params.casa.ms-field-spw-inputs
             caltable:

--- a/cultcargo/casa/concat.yml
+++ b/cultcargo/casa/concat.yml
@@ -7,12 +7,7 @@ cabs:
     casa.concat:
         info: Uses CASA concat to merge list of ms 
         command: casatasks.concat
-        flavour:
-            kind: python
-            interpreter_binary: python3.8
-        image: 
-            _use: vars.cult-cargo.images
-            name: casa6
+        _use: lib.misc.casa6.command-data
         inputs:
             _use: lib.params.casa.base-inputs
             timesort:

--- a/cultcargo/casa/flag.yml
+++ b/cultcargo/casa/flag.yml
@@ -7,12 +7,7 @@ cabs:
     casa.flagman:
         info: Uses CASA flagmanager to save/restore/list flagversions 
         command: casatasks.flagmanager
-        flavour:
-            kind: python
-            interpreter_binary: python3.8
-        image: 
-            _use: vars.cult-cargo.images
-            name: casa6
+        _use: lib.misc.casa6.command-data
         inputs:
             _use: lib.params.casa.base-inputs
             # TODO decide on the write_parent_dir: true
@@ -25,12 +20,7 @@ cabs:
     casa.flagsummary:
         info: Uses CASA flagdata to obtain a flag summary
         command: casatasks.flagdata
-        flavour:
-            kind: python
-            interpreter_binary: python3.8
-        image: 
-            _use: vars.cult-cargo.images
-            name: casa6
+        _use: lib.misc.casa6.command-data
         inputs:
             _use: lib.params.casa.base-inputs
             spw:
@@ -50,12 +40,7 @@ cabs:
     casa.flagdata:
         info: Uses CASA flagdata to perform flagging for different modes.
         command: casatasks.flagdata
-        flavour:
-            kind: python
-            interpreter_binary: python3.8
-        image: 
-            _use: vars.cult-cargo.images
-            name: casa6
+        _use: lib.misc.casa6.command-data
         inputs:
             _use: lib.params.casa.ms-field-spw-inputs
             #    write_parent_dir: true

--- a/cultcargo/casa/importgmrt.yml
+++ b/cultcargo/casa/importgmrt.yml
@@ -6,12 +6,7 @@ cabs:
     casa.importgmrt:
         info: Uses CASA import GMRT UVFITS to ms 
         command: casatasks.importgmrt
-        flavour:
-            kind: python
-            interpreter_binary: python3.8
-        image: 
-            _use: vars.cult-cargo.images
-            name: casa6
+        _use: lib.misc.casa6.command-data
         inputs:
             fitsfile:
                 info: The INPUT UVFITS file from GMRT 

--- a/cultcargo/casa/listobs.yml
+++ b/cultcargo/casa/listobs.yml
@@ -7,11 +7,6 @@ cabs:
     casa.listobs:
         info: Summarize dataset 
         command: casatasks.listobs
-        flavour:
-            kind: python
-            interpreter_binary: python3.8
-        image: 
-            _use: vars.cult-cargo.images
-            name: casa6
+        _use: lib.misc.casa6.command-data
         inputs:
             _use: lib.params.casa.base-inputs

--- a/cultcargo/casa/polcal.yml
+++ b/cultcargo/casa/polcal.yml
@@ -7,12 +7,7 @@ cabs:
     casa.polcal:
         info: Summarize dataset 
         command: casatasks.polcal
-        flavour:
-            kind: python
-            interpreter_binary: python3.8
-        image: 
-            _use: vars.cult-cargo.images
-            name: casa6
+        _use: lib.misc.casa6.command-data
         inputs:
             _use: lib.params.casa.ms-field-spw-inputs
             caltable:

--- a/cultcargo/casa/setjy.yml
+++ b/cultcargo/casa/setjy.yml
@@ -7,12 +7,7 @@ cabs:
     casa.setjy:
         info: Uses CASA flux density calibration 
         command: casatasks.setjy
-        flavour:
-            kind: python
-            interpreter_binary: python3.8
-        image: 
-            _use: vars.cult-cargo.images
-            name: casa6
+        _use: lib.misc.casa6.command-data
         inputs:
             _use: lib.params.casa.ms-field-spw-inputs
             standard:

--- a/cultcargo/casa/split.yml
+++ b/cultcargo/casa/split.yml
@@ -8,12 +8,7 @@ cabs:
     casa.split:
         info: Split casa task. 
         command: casatasks.split
-        flavour:
-            kind: python
-            interpreter_binary: python3.8
-        image: 
-            _use: vars.cult-cargo.images
-            name: casa6
+        _use: lib.misc.casa6.command-data
         inputs:
             _use: lib.params.casa.ms-field-spw-inputs
             ms:

--- a/cultcargo/genesis/casa/casa-inputs.yml
+++ b/cultcargo/genesis/casa/casa-inputs.yml
@@ -29,7 +29,7 @@ lib:
             command-data:
                 flavour:
                     kind: python
-                    interpreter_binary: python3.8
+                    interpreter_binary: python3.10
                 image: 
                     _use: vars.cult-cargo.images
                     name: casa6


### PR DESCRIPTION
This code moves the casa cabs to python3.10. Part of the tidying up from rebasing to refactor-0.2.0