### PR TITLE
Issue 107

### DIFF
--- a/cultcargo/astropy.yml
+++ b/cultcargo/astropy.yml
@@ -24,7 +24,7 @@ cabs:
     inputs:
       cache-dir:
         dtype: Directory
-        writable: true
+        mkdir: true
         implicit: =config.lib.misc.astropy.local-data-dir
     command: |
       import os
@@ -46,10 +46,13 @@ cabs:
         dtype: bool
         default: false
         info: clears cache, forcing a re-download
+    outputs:
       cache-dir:
         dtype: Directory
-        writable: true
         implicit: =config.lib.misc.astropy.local-data-dir
+        mkdir: true
+        policies:
+          skip: false  # pass it in as a variable since we print it below
     flavour: 
       kind: python-code
     command: |

--- a/cultcargo/casa/bandpass.yml
+++ b/cultcargo/casa/bandpass.yml
@@ -6,66 +6,36 @@ _include:
 cabs:
     casa.bandpass:
         info: "CASA 'bandpass' task: bandpass calibration" 
+        extra_info:
+            See also: https://casadocs.readthedocs.io/en/stable/api/tt/casatasks.calibration.bandpass.html
+
         command: casatasks.bandpass
         _use: lib.misc.casa6.command-data
-        inputs:
-            _use: lib.params.casa.ms-field-spw-inputs
+        outputs:
             caltable:
                 info: Name of output gain calibration table
-                dtype: str 
+                dtype: Directory 
                 required: true
-            intent:
-                info: Select observing intent
-                dtype: str 
-                default: ''
-            selectdata:
-                info: Other data selection parameters
-                dtype: bool 
-                default: true
-            timerange:
-                info: Select data based on time range (subparameter of selectdata=True)
-                dtype: str 
-                default: ''
-            uvrange:
-                info: Select data based on baseline length (subparameter of selectdata=True)
-                dtype: str 
-                default: ''
-            antenna:
-                info: Select data based on antenna/baseline (subparameter of selectdata=True)
-                dtype: str 
-                default: ''
-            scan:
-                info: Scan number range (subparameter of selectdata=True)
-                dtype: str 
-                default: ''
-            observation:
-                info: Select by observation ID(s) (subparameter of selectdata=True)
-                dtype: str 
-                default: ''
-            msselect:
-                info: Optional complex data selection (ignore for now)
-                dtype: str 
-                default: ''
+                mkdir: false
+        inputs:
+            _use: 
+                - lib.params.casa.ms-selectdata-inputs
+                - lib.params.casa.calibration-inputs
             solint:
                 info: Solution interval
                 dtype: str 
-                default: 'inf' 
             combine:
-                info: Data axes which to combine for solve. Options ‘’,’obs’,’scan’,’spw’,field’, or any comma-separated combination in a single string
+                info: Data axes which to combine for solve. Options are 'obs', 'scan', 'spw', 'field', or any comma-separated combination
                 dtype: str 
-                default: 'obs, scan' 
             refant:
                 info: Reference antenna. You may use any antenna that is working for the whole duration of the observation.
                 dtype: str 
-                required: true
             minblperant:
                 info: Minimum number of baselines required per antenna for each solve
                 dtype: int 
-                default: 4
             minsnr:
                 info: Reject solutions below this SNR
                 dtype: float
-                default: 3.0
             bandtype:
                 info: Type of bandpass solution
                 dtype: str
@@ -76,64 +46,30 @@ cabs:
             smodel:
                 info: Point source Stokes parameters for source model.
                 dtype: List[float]
-                default: []
             corrdepflags:
                 info: Respect correlation-dependent flags
                 dtype: bool
-                default: false
             append:
                 info: Append solutions to the (existing) table
                 dtype: bool 
-                default: false
             fillgaps:
-                info: fillgaps (int=0) - Fill flagged solution channels by interpolation Subparameter of bandtype=’B’ 
+                info: fillgaps (int=0) - Fill flagged solution channels by interpolation Subparameter of bandtype='B' 
                 dtype: int
-                default: 0
             degamp:
                 info: Polynomial degree for BPOLY amplitude solution
                 dtype: int 
-                default: 3
             degphase:
                 info: Polynomial degree for BPOLY phase solution
                 dtype: int 
-                default: 3
             visnorm:
-                info: visnorm (bool=False) - Normalize data prior to BPOLY solution Subparameter of bandtype=’BPOLY’
+                info: visnorm (bool=False) - Normalize data prior to BPOLY solution Subparameter of bandtype='BPOLY'
                 dtype: bool
-                default: false
             maskcenter:
-                info: Number of channels to avoid in center of each band Subparameter of bandtype=’BPOLY’
+                info: Number of channels to avoid in center of each band Subparameter of bandtype='BPOLY'
                 dtype: int 
-                default: 0
             maskedge:
-                info: Fraction of channels to avoid at each band edge (in %) Subparameter of bandtype=’BPOLY’
+                info: Fraction of channels to avoid at each band edge (in %) Subparameter of bandtype='BPOLY'
                 dtype: int 
-                default: 5        
-            docallib:
-                info: Control means of specifying the caltables
-                dtype: bool 
-                default: false
-            callib:
-                info: Specify a file containing cal library directives. Subparameter of docallib=True
-                dtype: str 
-                default: ''
-            gaintable:
-                info: Gain calibration table(s) to apply on the fly
-                dtype: List[str] 
-                default: []
-            gainfield:
-                info: Select a subset of calibrators from gaintable(s). Subparameter of callib=False
-                dtype: List[str] 
-                default: []
-            interp:
-                info: Interpolation parmameters (in time[,freq]) for each gaintable, as a list of strings.
-                dtype: List[str] 
-                default: []
-            spwmap:
-                info: Spectral window mappings to form for gaintable(s)
-                dtype: List[int]
-                default: []
             parang:
                 info: Apply parallactic angle correction
                 dtype: bool 
-                default: false

--- a/cultcargo/casa/calibration.yml
+++ b/cultcargo/casa/calibration.yml
@@ -6,98 +6,46 @@ _include:
 cabs:
     casa.applycal:
         info: "CASA 'applycal' task: applies calibration tables and generates corrected data" 
+        extra_info:
+            See also: https://casadocs.readthedocs.io/en/stable/api/tt/casatasks.calibration.applycal.html
         command: casatasks.applycal
         _use: lib.misc.casa6.command-data
         inputs:
-            _use: lib.params.casa.ms-field-spw-inputs
-            intent:
-                info: Select observing intent
-                dtype: str 
-                default: ''
-            selectdata:
-                info: Other data selection parameters
-                dtype: bool 
-                default: true
-            timerange:
-                info: Select data based on time range (subparameter of selectdata=True)
-                dtype: str 
-                default: ''
-            uvrange:
-                info: Select data based on baseline length (subparameter of selectdata=True)
-                dtype: str 
-                default: ''
-            antenna:
-                info: Select data based on antenna/baseline (subparameter of selectdata=True)
-                dtype: str 
-                default: ''
-            scan:
-                info: Scan number range (subparameter of selectdata=True)
-                dtype: str 
-                default: ''
-            observation:
-                info: Select by observation ID(s) (subparameter of selectdata=True)
-                dtype: str 
-                default: ''
-            msselect:
-                info: Optional complex data selection (ignore for now)
-                dtype: str 
-                default: ''
-            docallib:
-                info: Control means of specifying the caltables
-                dtype: bool 
-                default: false
-            callib:
-                info: Specify a file containing cal library directives. Subparameter of docallib=True
-                dtype: str 
-                default: ''
-            gaintable:
-                info: Gain calibration table(s) to apply on the fly
-                dtype: List[str] 
-                default: []
-            gainfield:
-                info: Select a subset of calibrators from gaintable(s). Subparameter of callib=False
-                dtype: List[str] 
-                default: []
-            interp:
-                info: Interpolation parmameters (in time[,freq]) for each gaintable, as a list of strings.
-                dtype: List[str] 
-                default: []
-            spwmap:
-                info: Spectral window mappings to form for gaintable(s)
-                dtype: List[int]
-                default: []
+            _use: 
+                - lib.params.casa.ms-selectdata-inputs
+                - lib.params.casa.calibration-inputs
             calwt:
                 info: Calibrate data weights per gaintable.
                 dtype: List[bool]
-                default: [true]
+            applymode:
+                info: Calibration apply mode (default is 'calflag')
+                dtype: str 
+                choices: [calflag, calflagstrict, trial, flagonly, flagonlystrict, calonly]
+            flagbackup:
+                info: Automatically back up the state of flags before the run? Default is true
+                dtype: bool 
             parang:
                 info: Apply parallactic angle correction
                 dtype: bool 
-                default: false
-            applymode:
-                info: Calibration apply mode
-                dtype: str 
-                choices: [calflag, calflagstrict, trial, flagonly, flagonlystrict, calonly]
-                default: calflag
-            flagbackup:
-                info: Automatically back up the state of flags before the run?
-                dtype: bool 
-                default: true
                 
 
     casa.fluxscale:
         info: "CASA 'fluxscale' task: bootstraps the flux density scale from standard calibrators"      
+        extra_info:
+            See also: https://casadocs.readthedocs.io/en/stable/api/tt/casatasks.calibration.fluxscale.html
         command: casatasks.fluxscale
         _use: lib.misc.casa6.command-data
+        outputs:
+            fluxtable:
+                info: Name of output flux-scaled calibation table
+                dtype: Directory
+                required: true
+                mkdir: false
         inputs:
             _use: lib.params.casa.base-inputs
             caltable:
                 info: Name of input calibation table
-                dtype: str 
-                required: true
-            fluxtable:
-                info: Name of output flux-scaled calibation table
-                dtype: str 
+                dtype: Directory
                 required: true
             reference:
                 info: Reference field name(s) (transfer flux scale FROM
@@ -106,103 +54,62 @@ cabs:
             transfer:
                 info: Transfer field name(s) (transfer flux scale TO)
                 dtype: str 
-                default: ''
             listfile:
                 info: Name of listfile that contains the fit information
                 dtype: str 
-                default: ''
             append:
                 info: Append fluxscaled solutions to the fluxtable?
                 dtype: bool
-                default: false
             refspwmap:
-                info: Vector of spectral windows enabling scaling across
+                info: Scale across spectral window boundaries
                 dtype: List[int]
-                default: [-1]
             gainthreshold:
                 info: Threshold in the input gain solutions to be used in fractional deviation from median values.
                 dtype: float
-                default: -1.0
-            antenna:
-                info: Select data based on antenna/baseline
-                dtype: str 
-                default: ''
             timerange:
-                info: Select data based on time range
+                info: Select based on time range. E.g. '09:14:0~09:54:0', default ('') is all
                 dtype: str 
-                default: ''
+            antenna:
+                info: Select antenna/baselines. E.g. '3,VA04', default ('') is all
+                dtype: str 
             scan:
-                info: Scan number range
+                info: Select based on scan number range, e.g. '0~5'
                 dtype: str 
-                default: ''
             incremental:
                 info: Create an incremental caltable containing only gain correction factor?
                 dtype: bool
-                default: false
             fitorder:
                 info: Polynomial order of the spectral fitting for valid flux
                 dtype: int
-                default: 1
             display:
                 info: Display statistics and/or spectral fitting results?
                 dtype: bool
-                default: false
                 
             
     casa.gaincal:
         info: "CASA 'gaincal' task: gain calibration"      
+        extra_info:
+            See also: https://casadocs.readthedocs.io/en/stable/api/tt/casatasks.calibration.gaincal.html
         command: casatasks.gaincal
-        _use: lib.misc.casa6.command-data
-        inputs:
-            _use: lib.params.casa.ms-field-spw-inputs
+        outputs:
             caltable:
                 info: Name of output gain calibration table
-                dtype: str 
+                dtype: Directory 
                 required: true
-            intent:
-                info: Select observing intent
-                dtype: str 
-                default: ''
-            selectdata:
-                info: Other data selection parameters
-                dtype: bool 
-                default: true
-            timerange:
-                info: Select data based on time range (subparameter of selectdata=True)
-                dtype: str 
-                default: ''
-            uvrange:
-                info: Select data based on baseline length (subparameter of selectdata=True)
-                dtype: str 
-                default: ''
-            antenna:
-                info: Select data based on antenna/baseline (subparameter of selectdata=True)
-                dtype: str 
-                default: ''
-            scan:
-                info: Scan number range (subparameter of selectdata=True)
-                dtype: str 
-                default: ''
-            observation:
-                info: Select by observation ID(s) (subparameter of selectdata=True)
-                dtype: str 
-                default: ''
-            msselect:
-                info: Optional complex data selection (ignore for now)
-                dtype: str 
-                default: ''
+                mkdir: false
+        inputs:
+            _use: 
+                - lib.params.casa.ms-selectdata-inputs
+                - lib.params.casa.calibration-inputs
             solint:
                 info: Solution interval
                 dtype: str 
-                default: 'inf' 
             combine:
-                info: Data axes which to combine for solve. Options ‘’,’obs’,’scan’,’spw’,field’, or any comma-separated combination in a single string
+                info: Data axes which to combine for solve. Options are 'obs', 'scan', 'spw', 'field', or any comma-separated combination
                 dtype: str 
-                default: '' 
             preavg:
-                info: Pre-averaging interval (sec)
+                info: Pre-averaging interval (sec), default is -1 to disable
                 dtype: float
-                default: -1.0
             refant:
                 info: Reference antenna. You may use any antenna that is working for the whole duration of the observation.
                 dtype: str 
@@ -210,88 +117,52 @@ cabs:
             refantmode:
                 info: Reference antenna mode 
                 dtype: str 
-                default: 'flex'
             minblperant:
                 info: Minimum number of baselines required per antenna for each solve
                 dtype: int 
-                default: 4
             minsnr:
                 info: Reject solutions below this SNR
                 dtype: float
-                default: 3.0
             solnorm:
                 info: Normalize (squared) solution amplitudes (G, T only)
                 dtype: bool 
-                default: false
             normtype:
                 info: Solution normalization calculation type
                 dtype: str
                 choices: [mean, median]
-                default: mean
             gaintype:
                 info: Type of gain solution (G,T,GSPLINE,K,KCROSS)
                 dtype: str
                 choices: [G,T,GSPLINE,K,KCROSS]
-                default: G
             # smodel:
             #   info: Point source Stokes parameters for source model (experimental).
             calmode:
-                info: Type of solution” ('ap', 'p', 'a')
+                info: Type of solution ('ap', 'p', 'a')
                 dtype: str
                 choices: [ap, p, a]
-                default: ap
             solmode:
-                info: Robust solving mode Options ‘’, ‘L1’, ‘R’, ‘L1R’
+                info: Robust solving mode ('', 'L1', 'R', 'LR')
                 dtype: str
                 choices: [ '', L1, R, L1R ]
-                default: ''
             rmsthresh:
-                info: RMS Threshold sequence. Subparameter of solmode=’R’ or ‘L1R’
+                info: RMS Threshold sequence. Subparameter of solmode='R' or 'L1R'                
                 dtype: List[float]
-                default: []
             corrdepflags:
                 info: See CASA docs
                 dtype: bool 
-                default: false
             append:
                 info: Append solutions to the (existing) table
                 dtype: bool 
-                default: false
             splinetime:
                 info: Spline timescale(sec); All spw's are first averaged. Subparameter of gaintype=’GSPLINE’
                 dtype: float
-                default: 3600.0
             npointaver:
                 info: Tune phase-wrapping algorithm.
                 dtype: int
-                default: 3
             phasewrap:
                 info: Wrap the phase for jumps greater than this value (degrees)
                 dtype: float
-                default: 180.0
-            docallib:
-                info: Control means of specifying the caltables
-                dtype: bool 
-                default: false
-            callib:
-                info: Specify a file containing cal library directives. Subparameter of docallib=True
-                dtype: str 
-                default: ''
-            gaintable:
-                info: Gain calibration table(s) to apply on the fly
-                dtype: List[str] 
-                default: []
-            interp:
-                info: Interpolation parmameters (in time[,freq]) for each gaintable, as a list of strings.
-                dtype: List[str] 
-                default: []
-            spwmap:
-                info: Spectral window mappings to form for gaintable(s)
-                dtype: List[int]
-                default: []
             parang:
                 info: Apply parallactic angle correction
                 dtype: bool 
-                default: false
-
          

--- a/cultcargo/casa/concat.yml
+++ b/cultcargo/casa/concat.yml
@@ -6,25 +6,36 @@ _include:
 cabs:
     casa.concat:
         info: "CASA 'concat' task: concatenates MSs" 
+        extra_info:
+            See also: https://casadocs.readthedocs.io/en/stable/api/tt/casatasks.manipulation.concat.html        
         command: casatasks.concat
         _use: lib.misc.casa6.command-data
         inputs:
             _use: lib.params.casa.base-inputs
             timesort:
+                info: If true, sort by TIME in ascending order
                 dtype: bool    
             freqtol:
+                info: Frequency shift tolerance for considering data as the same spwid
                 dtype: str
             dirtol:
+                info: Direction shift tolerance for considering data as the same field
                 dtype: str
             respectname:
+                info: If true, fields with a different name are not merged even if their direction agrees
                 dtype: bool
             copypointing:
+                info: Copy all rows of the POINTING table, default is true
                 dtype: bool
             visweightscale:
+                info: List of the weight scaling factors to be applied to the individual MSs
                 dtype: List[float]
             forcesingleephemfield:
+                info: Make sure that there is only one joint ephemeris for every field in this list
                 dtype: List[str]
         outputs:
-            concatvis:
+            output-ms:
+                info: output MS
                 dtype: MS
                 required: true
+                nom_de_guerre: concatvis

--- a/cultcargo/casa/flag.yml
+++ b/cultcargo/casa/flag.yml
@@ -6,6 +6,8 @@ _include:
 cabs:
     casa.flagman:
         info: "CASA 'flagmanager' task: saves/restores flags" 
+        extra_info:
+            See also: https://casadocs.readthedocs.io/en/stable/api/tt/casatasks.flagging.flagmanager.html
         command: casatasks.flagmanager
         _use: lib.misc.casa6.command-data
         inputs:
@@ -41,12 +43,15 @@ cabs:
 
     casa.flagdata:
         info: "CASA 'flagdata' task: performs flagging" 
+        extra_info:
+            See also: https://casadocs.readthedocs.io/en/stable/api/tt/casatasks.flagging.flagdata.html
         command: casatasks.flagdata
         _use: lib.misc.casa6.command-data
         inputs:
             _use: lib.params.casa.ms-field-spw-inputs
+            _scrub: selectdata, msselect   # these ones not implemented by this task
             mode:
-                info: Flagging mode
+                info: Flagging mode, defult is 'manual'
                 choices:
                     - manual
                     - clip
@@ -57,31 +62,12 @@ cabs:
                     - rflag
                     - extend
                     - unflag
-                default: manual
-                dtype: str
-            antenna:
-                info: Antenna/baselines. e.g. '' ==> all, antenna ='3,VA04'
-                dtype: str
-            timerange:
-                info: Time range. e.g. '' ==> all,timerange='09:14:0~09:54:0'
                 dtype: str
             correlation:
-                info: Correlation. e.g. '' ==> all, correlation='XX,YY'
-                dtype: str
-            scan:
-                info: Scan numbers. e.g. '' ==> all
-                dtype: str
-            intent:
-                info: Observation intent. e.g. '' ==> all, intent='CAL*POINT*'
+                info: Correlation. E.g. 'XX,YY'
                 dtype: str
             array:
-                info: (Sub)array numbers. e.g. '' ==> all
-                dtype: str
-            uvrange:
-                info: UV range. e.g. '' ==> all; uvrange ='0~100klambda', default units=meters
-                dtype: str
-            observation:
-                info: Observation ID. e.g. '' ==> all
+                info: (Sub)array numbers
                 dtype: str
             feed:
                 info: Multi-feed numbers. Not yet implemented
@@ -93,7 +79,7 @@ cabs:
                 info: Input ASCII file, list of files or Python list of strings with flag commands
                 dtype: str
             datacolumn:
-                info: Data column on which to operate (data,corrected,model,weight,etc.)
+                info: Data column on which to operate (data, corrected, model, weight, etc.)
                 dtype: str
             reason:
                 info: Select by REASON types
@@ -118,15 +104,14 @@ cabs:
                 dtype: float
             quackmode:
                 info: |-
-                    Quack mode. 'beg' ==> first n seconds of scan.'endb' ==> last n
-                    seconds of scan. 'end' ==> all but first n seconds of scan. 'tail' ==>
-                    all but last n seconds of scan.
+                    Quack mode. Default is 'beg' ==> first N seconds of scan; 'endb' ==> last N
+                    seconds of scan; 'end' ==> all but first N seconds of scan; 'tail' ==>
+                    all but last N seconds of scan.
                 choices:
                     - beg
                     - endb
                     - end
                     - tail
-                default: beg
                 dtype: str
             quackincrement:
                 info: Flag incrementally in time?
@@ -157,39 +142,35 @@ cabs:
                 info: Flagging thresholds in units of deviation from the fit
                 dtype: float
             timefit:
-                info: Fitting function for the time direction (poly/line)
+                info: Fitting function for the time direction (poly/line), default is line
                 choices:
                     - poly
                     - line
-                default: line
                 dtype: str
             freqfit:
-                info: Fitting function for the frequency direction (poly/line)
+                info: Fitting function for the frequency direction (poly/line), default is poly
                 choices:
                     - poly
                     - line
-                default: poly
                 dtype: str
             maxnpieces:
                 info: Number of pieces in the polynomial-fits (for 'freqfit' or 'timefit' ='poly')
                 dtype: int
             flagdimension:
-                info: Dimensions along which to calculate fit
+                info: Dimensions along which to calculate fit, default is 'freqtime'
                 choices:
                     - freq
                     - time
                     - freqtime
                     - timefreq
-                default: freqtime
                 dtype: str
             usewindowstats:
-                info: Calculate additional flags using sliding window statistics
+                info: Calculate additional flags using sliding window statistics, default is 'none'
                 choices:
                     - none
                     - sum
                     - std
                     - both
-                default: none
                 dtype: str
             halfwin:
                 info: Half-width of sliding window to use with 'usewindowstats' (1,2,3).
@@ -225,8 +206,7 @@ cabs:
                 info: minimum number of flags (absolute)
                 dtype: int
             maxabs:
-                info: maximum number of flags (absolute). Use a negative value to indicate infinity.
-                default: -1
+                info: maximum number of flags (absolute). Use a negative value to indicate infinity (this is the default)
                 dtype: int
             spwchan:
                 info: Print summary of channels per spw
@@ -238,25 +218,22 @@ cabs:
                 info: Print summary counts per baseline
                 dtype: bool
             name:
-                info: Name of this summary report (key in summary dictionary)
-                default: Summary
+                info: Name of this summary report (key in summary dictionary), default is 'Summary'
                 dtype: str
             action:
-                info: Action to perform in MS and/or in inpfile
+                info: Action to perform in MS and/or in inpfile, default is 'none'
                 choices:
                     - none
                     - apply
                     - calculate
-                default: 'none'
                 dtype: str
             display:
-                info: Display data and/or end-of-MS reports at runtime
+                info: Display data and/or end-of-MS reports at runtime, default is 'report'
                 choices:
                     - data
                     - report
                     - both
                     - none
-                default: 'report'
                 dtype: str
             flagbackup:
                 info: Back up the state of flags before the run
@@ -293,9 +270,7 @@ cabs:
                 dtype: float
             chanbin:
                 info: Bin width for channel average in number of input channels
-                default: 1
                 dtype: int
             overwrite:
-                info: Overwrite the existing parameter file given in outfile
+                info: Overwrite the existing parameter file given in outfile, default is true
                 dtype: bool
-                default: true

--- a/cultcargo/casa/importgmrt.yml
+++ b/cultcargo/casa/importgmrt.yml
@@ -5,16 +5,18 @@ _include:
 cabs:
     casa.importgmrt:
         info: "CASA 'importgmrt' task: imports GMRT UVFITS to ms"
+        extra_info:
+            See also: https://casadocs.readthedocs.io/en/stable/api/tt/casatasks.data.importgmrt.html
         command: casatasks.importgmrt
         _use: lib.misc.casa6.command-data
         inputs:
             fitsfile:
-                info: The INPUT UVFITS file from GMRT 
+                info: UVFITS file from GMRT 
                 dtype: File
                 required: true
         outputs:
             vis:
-                info: The OUTPUT measurement set.
+                info: Output measurement set
                 dtype: MS
                 required: true
                 mkdir: false

--- a/cultcargo/casa/importgmrt.yml
+++ b/cultcargo/casa/importgmrt.yml
@@ -15,8 +15,9 @@ cabs:
                 dtype: File
                 required: true
         outputs:
-            vis:
+            ms:
                 info: Output measurement set
                 dtype: MS
                 required: true
                 mkdir: false
+                nom_de_guerre: vis

--- a/cultcargo/casa/importgmrt.yml
+++ b/cultcargo/casa/importgmrt.yml
@@ -4,7 +4,7 @@ _include:
 
 cabs:
     casa.importgmrt:
-        info: "CASA 'importgmrt' task: imports GMRT UVFITS to ms"
+        info: "CASA 'importgmrt' task: imports GMRT UVFITS file into an MS"
         extra_info:
             See also: https://casadocs.readthedocs.io/en/stable/api/tt/casatasks.data.importgmrt.html
         command: casatasks.importgmrt

--- a/cultcargo/casa/plotms.yml
+++ b/cultcargo/casa/plotms.yml
@@ -7,6 +7,8 @@ _include:
 cabs:
   casa.plotms:
     info: "CASA 'plotms' task: generates plots based on an MS" 
+    extra_info:
+        See also: https://casadocs.readthedocs.io/en/stable/api/tt/casaplotms.plotms.html
     command: casaplotms.plotms
     _use: 
       - lib.misc.casa6.command-data
@@ -20,9 +22,9 @@ cabs:
             host: /run/user
     inputs:
       ms:
-        info: Input MS or CalTable (blank for none)
+        info: Input MS or CalTable
         required: true
-        dtype: MS
+        dtype: Union[MS, Directory]
         nom_de_guerre: vis
       gridrows:
         info: Number of subplot rows
@@ -664,7 +666,7 @@ cabs:
         info: Outline plotted flagged symbols
         dtype: bool
       xconnector:
-        info: Set connector for data points (blank="none"; "line","step")
+        info: Set connector for data points (blank="none"; "line", "step")
         dtype: str
         choices:
         - none
@@ -784,13 +786,13 @@ cabs:
       showgui:
         info: Show GUI
         dtype: bool
-        implicit: False
+        implicit: False   # always False in pipelines
       clearplots:
         info: Remove any existing plots so new ones can replace them.
         dtype: bool
       callib:
         info: Calibration library string or filename for on-the-fly calibration.
-        dtype: str
+        dtype: File
       headeritems:
         info: Comma-separated list of pre-defined page header items.
         dtype: str

--- a/cultcargo/casa/polcal.yml
+++ b/cultcargo/casa/polcal.yml
@@ -6,58 +6,30 @@ _include:
 cabs:
     casa.polcal:
         info: "CASA 'polcal' task: polarization calibration" 
+        extra_info:
+            See also: https://casadocs.readthedocs.io/en/stable/api/tt/casatasks.calibration.polcal.html
         command: casatasks.polcal
         _use: lib.misc.casa6.command-data
-        inputs:
-            _use: lib.params.casa.ms-field-spw-inputs
+        outputs:
             caltable:
                 info: Name of output gain calibration table
-                dtype: str 
+                dtype: Directory 
                 required: true
-            intent:
-                info: Select observing intent
-                dtype: str 
-                default: ''
-            selectdata:
-                info: Other data selection parameters
-                dtype: bool 
-                default: true
-            timerange:
-                info: Select data based on time range (subparameter of selectdata=True)
-                dtype: str 
-                default: ''
-            uvrange:
-                info: Select data based on baseline length (subparameter of selectdata=True)
-                dtype: str 
-                default: ''
-            antenna:
-                info: Select data based on antenna/baseline (subparameter of selectdata=True)
-                dtype: str 
-                default: ''
-            scan:
-                info: Scan number range (subparameter of selectdata=True)
-                dtype: str 
-                default: ''
-            observation:
-                info: Select by observation ID(s) (subparameter of selectdata=True)
-                dtype: str 
-                default: ''
-            msselect:
-                info: Optional complex data selection (ignore for now)
-                dtype: str 
-                default: ''
+                mkdir: false
+        inputs:
+            _use: 
+                - lib.params.casa.ms-selectdata-inputs
+                - lib.params.casa.calibration-inputs
             solint:
                 info: Solution interval
                 dtype: str 
                 default: 'inf' 
             combine:
-                info: Data axes which to combine for solve. Options ‘’,’obs’,’scan’,’spw’,field’, or any comma-separated combination in a single string
+                info: Data axes which to combine for solve. Options are 'obs', 'scan', 'spw', 'field', or any comma-separated combination
                 dtype: str 
-                default: 'obs, scan' 
             preavg:
                 info: Pre-averaging interval (sec)
                 dtype: float
-                default: 300.0
             refant:
                 info: Reference antenna. You may use any antenna that is working for the whole duration of the observation.
                 dtype: str 
@@ -65,36 +37,12 @@ cabs:
             minblperant:
                 info: Minimum number of baselines required per antenna for each solve
                 dtype: int 
-                default: 4
             minsnr:
                 info: Reject solutions below this SNR
                 dtype: float
-                default: 3.0
             poltype:
-                info: Type of instrumental polarization solution
+                info: Type of instrumental polarization solution, default is D+QU
                 dtype: str
-                default: 'D+QU'
             append:
                 info: Append solutions to the (existing) table
                 dtype: bool 
-                default: false
-            docallib:
-                info: Control means of specifying the caltables
-                dtype: bool 
-                default: false
-            callib:
-                info: Specify a file containing cal library directives. Subparameter of docallib=True
-                dtype: str 
-                default: ''
-            gaintable:
-                info: Gain calibration table(s) to apply on the fly
-                dtype: List[str] 
-                default: []
-            interp:
-                info: Interpolation parmameters (in time[,freq]) for each gaintable, as a list of strings.
-                dtype: List[str] 
-                default: []
-            spwmap:
-                info: Spectral window mappings to form for gaintable(s)
-                dtype: List[int]
-                default: []

--- a/cultcargo/casa/setjy.yml
+++ b/cultcargo/casa/setjy.yml
@@ -9,13 +9,16 @@ cabs:
         command: casatasks.setjy
         _use: lib.misc.casa6.command-data
         inputs:
-            _use: lib.params.casa.ms-field-spw-inputs
+            _use: 
+                - lib.params.casa.ms-selectdata-inputs
+            _scrub: antenna, uvrange, msselect   # not used by this task
             standard:
                 dtype: str 
-                default: 'Perley-Butler 2017'
-                info: Which standard to use 
+                info: |
+                    Which standard to use. Default is 'Perley-Butler 2017', alternatives are 
+                    'Perley-Butler 2013', 'Perley-Butler 2010', 'Butler-JPL-Horizons 2012', 
+                    'manual', 'fluxscale'
             usescratch:
                 dtype: bool
-                default: true
-                info: Will create if necessary and use the MODEL_DATA
+                info: Will create if necessary and use the MODEL_DATA column, default is true
                 

--- a/cultcargo/casa/split.yml
+++ b/cultcargo/casa/split.yml
@@ -6,25 +6,35 @@ _include:
 cabs:
             
     casa.split:
-        info: "CASA 'split' task: splits out subset of MS" 
+        info: "CASA 'split' task: splits out a subset of MS" 
+        extra_info:
+            See also: https://casadocs.readthedocs.io/en/stable/api/tt/casatasks.manipulation.split.html        
         command: casatasks.split
         _use: lib.misc.casa6.command-data
         inputs:
-            _use: lib.params.casa.ms-field-spw-inputs
+            _use: 
+                - lib.params.casa.ms-selectdata-inputs
+            _scrub: selectdata, msselect        # not used in this task
+            # make MS read-only
             ms:
                 writable: false
-            uvrange:
-                info: Select data by baseline length
-                dtype: str 
-                default: ''
+            # additional selections
+            correlation:
+                info: Correlation. E.g. 'XX,YY'
+                dtype: str
+            array:
+                info: (Sub)array numbers
+                dtype: str
+            feed:
+                info: Multi-feed numbers. Not yet implemented
+                dtype: str
             datacolumn:
-                info: Which data column(s) to process
+                info: Which data column(s) to process, default is corrected
                 dtype: str 
                 choices: 
                     - data
                     - corrected
                     - model
-                default: corrected
             width:
                 info: Number of channels to average to form one output channel
                 dtype: int 
@@ -38,4 +48,3 @@ cabs:
                 required: true
                 mkdir: false
                 nom_de_guerre: outputvis
-

--- a/cultcargo/genesis/casa/casa-inputs.yml
+++ b/cultcargo/genesis/casa/casa-inputs.yml
@@ -7,6 +7,7 @@
 lib:
     params:
         casa:
+            # base input - MS
             base-inputs:
                 ms:
                     dtype: MS
@@ -14,16 +15,69 @@ lib:
                     required: true
                     nom_de_guerre: vis
                     writable: true
+            # MS + field + spw
             ms-field-spw-inputs:
                 _use: lib.params.casa.base-inputs
                 spw:
                     info: Select spectral window/channels. e.g. spw='0:17~19'. Default all
                     dtype: str 
-                    default: ''
                 field:
                     info: Select field using field id(s) or field name(s) eg, field='0~2,3C286'. Default all fields
                     dtype: str 
-                    default: ''
+
+            # As the above, plus common selectdata parameters
+            ms-selectdata-inputs:
+                _use: lib.params.casa.ms-field-spw-inputs
+                intent:
+                    info: Select based on observing intent. E.g. 'CAL*POINT*', default ('') is all
+                    dtype: str 
+                selectdata:
+                    info: Enables extended data selection parameters
+                    dtype: bool
+                    # always enable, so other parameters take effect if needed 
+                    implicit: true
+                timerange:
+                    info: Select based on time range. E.g. '09:14:0~09:54:0', default ('') is all
+                    dtype: str 
+                uvrange:
+                    info: Select based on baseline length. E.g. '0~100klambda', '0~100' (meters), default ('') is all
+                    dtype: str 
+                antenna:
+                    info: Select antenna/baselines. E.g. '3,VA04', default ('') is all
+                    dtype: str 
+                scan:
+                    info: Select based on scan number range, e.g. '0~5'
+                    dtype: str 
+                observation:
+                    info: Select based on observation ID(s) 
+                    dtype: str 
+                msselect:
+                    info: Select based on TaQL query
+                    dtype: str 
+
+            # standard set of inputs for calibration tasks
+            calibration-inputs:
+                callib:
+                    info: Specify a file containing cal library directives 
+                    dtype: File 
+                docallib:
+                    info: If true, use cal library (callib) rather than gain tabes
+                    dtype: bool 
+                    # set implicitly if callib is set
+                    default: =IFSET(current.callib, True, False)
+                gaintable:
+                    info: Gain calibration table(s) to apply on the fly (use without callib)
+                    dtype: List[Directory] 
+                gainfield:
+                    info: Select a subset of calibrators from gaintable(s) (use without callib)
+                    dtype: List[str] 
+                interp:
+                    info: Interpolation parmameters (in time[,freq]) for each gaintable, as a list of strings (use without callib)
+                    dtype: List[str] 
+                spwmap:
+                    info: Spectral window mappings to form for gaintable(s) (use without callib)
+                    dtype: List[int]
+
     misc:
         casa6:
             command-data:
@@ -39,3 +93,4 @@ lib:
                             dot-casa:
                                 host: empty
                                 target: ~/.casa
+


### PR DESCRIPTION
This cleans up the CASA cabs by:

* removing most defaults (the, ahem, "default" pattern should be for Stimela not to provide a default value, and let the CASA-defined default handling take effect)

* Changing things like caltables from ``str`` to ``Directory``, and declaring output caltables as outputs

* Moving groups of duplicate parameters into ``genesis/casa/casa-inputs.yml`` for re-_use

* Adding an "extra_info: See also" section with a link to the appropriate CASA docs

@tmolteno @bennahugo @landmanbester @SirFelixOtieno could you please test that your recipes still run with these updated cab definitions.