### PR TITLE
Do not require both output_gaul and output_srl

### DIFF
--- a/cultcargo/bdsf.yml
+++ b/cultcargo/bdsf.yml
@@ -119,6 +119,8 @@ cabs:
     outputs:
       outfile_gaul:
         dtype: File
+        required: false
       outfile_srl:
         dtype: File
+        required: false
 


### PR DESCRIPTION
Only one should need to be specified.