### PR TITLE
Add path policies to new flagmanager cabs 

### DIFF
--- a/cultcargo/casa/flag.yml
+++ b/cultcargo/casa/flag.yml
@@ -128,6 +128,8 @@ cabs:
                 writable: true
                 policies:
                     skip: true  # Not an input to the command.
+                path_policies:
+                    write_parent: true
 
     casa.flagsummary:
         name: casa.flagsummary


### PR DESCRIPTION
CASA's flagmanager task seems to open the tables in read/write mode, regardless of whether the operation requires writes. This causes the `restore` cab to fail mysteriously. The fix is simply adding the relevant path policy.