### PR TITLE
fixes #136

### DIFF
--- a/cultcargo/builder/cargo-manifest.yml
+++ b/cultcargo/builder/cargo-manifest.yml
@@ -204,6 +204,8 @@ images:
         package: git+https://github.com/ratt-ru/tricolour
 
   smops:
+    assign:
+      extra_deps: git+https://github.com/caracal-pipeline/stimela@2.0rc4
     versions:
       '0.1.7':
         package: smops==0.1.7
@@ -227,8 +229,6 @@ images:
     assign:
       CMD: goquartical
     versions:
-      '0.2.2':
-        package: quartical==0.2.2
       '0.2.3':
         package: quartical==0.2.3
       '0.2.4':

--- a/cultcargo/genesis/cult-cargo-base.yml
+++ b/cultcargo/genesis/cult-cargo-base.yml
@@ -2,7 +2,7 @@ vars:
   cult-cargo:
     images:
       registry: quay.io/stimela2
-      version: cc0.2.0
+      version: cc0.2.1
 
 lib:
   misc:

--- a/cultcargo/genesis/wsclean/wsclean-base.yml
+++ b/cultcargo/genesis/wsclean/wsclean-base.yml
@@ -237,6 +237,9 @@ lib:
             - wgridder
             - tuned-wgridder
             - wstacking
+        use-wgridder:
+          info: deprecated option, use '-gridder wgridder' instead
+          dtype: bool
         shift:
           info: Shift the phase centre to the given location. The shift is along the tangential plane.
           dtype: List[str]

--- a/cultcargo/images/ddfacet/Dockerfile
+++ b/cultcargo/images/ddfacet/Dockerfile
@@ -1,57 +1,58 @@
-# better than the lite python images -- otherwise numpy 2 causes kak
-FROM ubuntu:22.04
-
-# FROM {REGISTRY}/ddfacet:{VERSION}-cc0.1.2
+FROM {REGISTRY}/ddfacet:{VERSION}-cc0.2.0
 #{REGISTRY}/python-base:{default_python_version}-{BUNDLE_VERSION}
 
-ENV DEBIAN_FRONTEND noninteractive
-ENV DEBIAN_PRIORITY critical
+# # better than the lite python images -- otherwise numpy 2 causes kak
+# FROM ubuntu:22.04
 
-RUN apt-get update && \
-   apt-get -y install \
-       dpkg-dev \
-       libc-dev \
-       cmake \
-       git \
-       wget \
-       subversion \
-       rsync \
-       python3-virtualenv \
-       python3-pip \
-       libfftw3-dev \
-       python3-numpy \
-       libfreetype6 \
-       libfreetype6-dev \
-       libpng-dev \
-       pkg-config \
-       python3-dev \
-       libboost-all-dev \
-       libcfitsio-dev \
-       libhdf5-dev \
-       wcslib-dev \
-       libatlas-base-dev \
-       liblapack-dev \
-       python3-tk \
-       libreadline6-dev \
-       subversion \
-       liblog4cplus-dev \
-       libhdf5-dev \
-       libncurses5-dev \
-       flex \
-       bison \
-       libbison-dev \
-       libqdbm-dev \
-       libgsl-dev \
-       make \
-   && rm -rf /var/lib/apt/lists/* \
-   && rm -rf /var/cache/apt/archives 
 
-{pre_install}
+# ENV DEBIAN_FRONTEND noninteractive
+# ENV DEBIAN_PRIORITY critical
 
-RUN python{default_python_version} -mpip install --use-pep517 --no-cache-dir -U matplotlib mpl-tools dask-ms python-casacore casadata ninja
-RUN python{default_python_version} -mpip install --use-pep517 --no-cache-dir {package} {extra_deps}
+# RUN apt-get update && \
+#    apt-get -y install \
+#        dpkg-dev \
+#        libc-dev \
+#        cmake \
+#        git \
+#        wget \
+#        subversion \
+#        rsync \
+#        python3-virtualenv \
+#        python3-pip \
+#        libfftw3-dev \
+#        python3-numpy \
+#        libfreetype6 \
+#        libfreetype6-dev \
+#        libpng-dev \
+#        pkg-config \
+#        python3-dev \
+#        libboost-all-dev \
+#        libcfitsio-dev \
+#        libhdf5-dev \
+#        wcslib-dev \
+#        libatlas-base-dev \
+#        liblapack-dev \
+#        python3-tk \
+#        libreadline6-dev \
+#        subversion \
+#        liblog4cplus-dev \
+#        libhdf5-dev \
+#        libncurses5-dev \
+#        flex \
+#        bison \
+#        libbison-dev \
+#        libqdbm-dev \
+#        libgsl-dev \
+#        make \
+#    && rm -rf /var/lib/apt/lists/* \
+#    && rm -rf /var/cache/apt/archives 
 
-{post_install}
+# {pre_install}
 
-CMD DDF.py --help
+# RUN python{default_python_version} -mpip install --use-pep517 --no-cache-dir -U matplotlib mpl-tools dask-ms python-casacore casadata ninja
+# RUN python{default_python_version} -mpip install --use-pep517 --no-cache-dir {package} {extra_deps}
+
+# {post_install}
+
+# CMD DDF.py --help
 

--- a/cultcargo/images/wsclean/Dockerfile.build
+++ b/cultcargo/images/wsclean/Dockerfile.build
@@ -2,7 +2,7 @@ FROM {REGISTRY}/base-cult:kern-{kern_version}-{BUNDLE_VERSION}
 
 RUN apt-get update && apt-get -y upgrade && \
     apt-get -y install cmake casacore-dev casacore-data libgsl-dev libhdf5-dev \
-        libfftw3-dev libboost-dev \
+        libfftw3-dev libboost-dev rsync \
         libboost-date-time-dev libboost-filesystem-dev \
         libboost-program-options-dev libboost-system-dev \
         libcfitsio-dev cmake g++ cmake \
@@ -17,6 +17,9 @@ RUN git clone https://gitlab.com/aroffringa/wsclean.git && \
     ln -s /build/wsclean /usr/bin && \
     ln -s /build/chgcentre /usr/bin && \
     rm -fr /wsclean
+
+RUN mkdir -p /usr/share/casacore/data/
+RUN rsync -az rsync://casa-rsync.nrao.edu/casa-data /usr/share/casacore/data
 
 CMD ["wsclean"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cult-cargo"
-version = "0.2.0"
+version = "0.2.1"
 description = "Curated cargo of standard radio astronomy packages for stimela 2.x"
 authors = ["Oleg Smirnov, Sphesihle Makhathini"]
 license = "MIT"


### PR DESCRIPTION
Fixes #136, I think. Also reinstates ``-use-wgridder`` for backwards compatibility (can always mark is as deprecated when we introduce that stimela feature). Also temporarily reuse old DDF image while waiting for a bugfix release.