### PR TITLE
Patches and improvements to blri_pycorr

### DIFF
--- a/cultcargo/blri_pycorr.yml
+++ b/cultcargo/blri_pycorr.yml
@@ -16,10 +16,9 @@ cabs:
 
     inputs:
       input_filepaths:
-        dtype: List[str]
+        dtype: str
         info: The path to the input files be it GUPPI RAW file stem or all filepaths; Seticore Stamps filepath
         policies:
-          repeat: list
           positional: true
       telescope-info-filepath:
         info: The path to telescope information (YAML/TOML or BFR5['telinfo'])
@@ -95,6 +94,6 @@ cabs:
     outputs:
       output-filepath:
         info: The path to which the output will be written (instead of alongside the raw_filepath)
-        dtype: Directory
+        dtype: File
         required: false
 

--- a/cultcargo/blri_pycorr.yml
+++ b/cultcargo/blri_pycorr.yml
@@ -16,7 +16,7 @@ cabs:
 
     inputs:
       input_filepaths:
-        dtype: str
+        dtype: File
         info: The path to the input files be it GUPPI RAW file stem or all filepaths; Seticore Stamps filepath
         policies:
           positional: true

--- a/cultcargo/blri_pycorr.yml
+++ b/cultcargo/blri_pycorr.yml
@@ -38,6 +38,7 @@ cabs:
         info: The polarisation characters for each polarisation, as a string (e.g. 'xy')
         dtype: str
         required: false
+        default: 'xy'
       frequency-mhz-begin:
         info: The lowest frequency (MHz) of the fine-spectra to analyse (at least 1 channel will be processed)
         required: false

--- a/cultcargo/blri_pycorr.yml
+++ b/cultcargo/blri_pycorr.yml
@@ -34,6 +34,11 @@ cabs:
         dtype: int
         default: 1
         required: false
+      dedispersion:
+        info: Dedrifting/dedispersion rate in Hz/s to apply after upchannelisation by upchannelisation-rate
+        dtype: float
+        default: 0.0
+        required: false
       polarisations:
         info: The polarisation characters for each polarisation, as a string (e.g. 'xy')
         dtype: str

--- a/cultcargo/builder/cargo-manifest.yml
+++ b/cultcargo/builder/cargo-manifest.yml
@@ -339,5 +339,5 @@ images:
       extra_deps: -U python-casacore pyuvdata
     versions:
       master:
-        package: git+https://github.com/MydonSolutions/BLRI.git
+        package: git+https://github.com/MydonSolutions/BLRI.git@add-dedispersion
 


### PR DESCRIPTION
1. Patch bad types for inputs
2. Input file is a single file at a time for simplicity
3. Set default for polarisation input
4. Use dedispersion instance of blri_pycorr. This means updating manifest to use new branch as well as adding the input to the cab.