### PR TITLE
Can has 0.2.1?!

### DIFF
--- a/bundle-manifest.md
+++ b/bundle-manifest.md
@@ -2,7 +2,7 @@
 
 |Image name|Default version|Alternatives|
 |----------|---------------|--------------|
-|**aimfast**|**master**-cc0.2.1|**1.3.4**-cc0.2.1|
+|**aimfast**|**1.3.4**-cc0.2.1||
 |**base-cult**|**kern-9**-cc0.2.1|**kern-7**-cc0.2.1&nbsp;&nbsp;**kern-8**-cc0.2.1&nbsp;&nbsp;**kern-dev**-cc0.2.1|
 |**bdsf**|**1.12.0**-cc0.2.1||
 |**blri_pycorr**|**master**-cc0.2.1||
@@ -19,11 +19,11 @@
 |**pfb-imaging**|cc0.2.1|**0.0.5**-cc0.2.1&nbsp;&nbsp;**0.0.6**-cc0.2.1&nbsp;&nbsp;**0.0.7**-cc0.2.1&nbsp;&nbsp;**0.0.8**-cc0.2.1&nbsp;&nbsp;**master**-cc0.2.1|
 |**python-astro**|**3.11**-cc0.2.1|**3.10**-cc0.2.1&nbsp;&nbsp;**3.12**-cc0.2.1&nbsp;&nbsp;**3.8**-cc0.2.1&nbsp;&nbsp;**3.9**-cc0.2.1|
 |**python-base**|**3.11**-cc0.2.1|**3.10**-cc0.2.1&nbsp;&nbsp;**3.12**-cc0.2.1&nbsp;&nbsp;**3.8**-cc0.2.1&nbsp;&nbsp;**3.9**-cc0.2.1|
-|**quartical**|cc0.2.1|**0.2.3**-cc0.2.1&nbsp;&nbsp;**0.2.4**-cc0.2.1&nbsp;&nbsp;**0.2.5**-cc0.2.1&nbsp;&nbsp;**0.2.6dev**-cc0.2.1&nbsp;&nbsp;**master**-cc0.2.1|
+|**quartical**|cc0.2.1|**0.2.3**-cc0.2.1&nbsp;&nbsp;**0.2.4**-cc0.2.1&nbsp;&nbsp;**0.2.5**-cc0.2.1|
 |**rfinder**|**master**-cc0.2.1||
 |**shadems**|cc0.2.1|**0.5.3**-cc0.2.1&nbsp;&nbsp;**0.5.4**-cc0.2.1&nbsp;&nbsp;**master**-cc0.2.1|
 |**smops**|cc0.2.1|**0.1.7**-cc0.2.1&nbsp;&nbsp;**master**-cc0.2.1|
-|**spimple**|**base**-cc0.2.1|**master**-cc0.2.1|
+|**spimple**|**base**-cc0.2.1||
 |**sunblocker**|**master**-cc0.2.1|**1.0.1**-cc0.2.1|
 |**tricolour**|cc0.2.1|**0.1.8.2**-cc0.2.1&nbsp;&nbsp;**master**-cc0.2.1|
 |**wsclean**|**3.6-haswell**-cc0.2.1|**2.10.1-kern7**-cc0.2.1&nbsp;&nbsp;**3.0.1-haswell**-cc0.2.1&nbsp;&nbsp;**3.1-haswell**-cc0.2.1&nbsp;&nbsp;**3.1-kern8**-cc0.2.1&nbsp;&nbsp;**3.2-haswell**-cc0.2.1&nbsp;&nbsp;**3.3-haswell**-cc0.2.1&nbsp;&nbsp;**3.4-haswell**-cc0.2.1&nbsp;&nbsp;**3.5-haswell**-cc0.2.1&nbsp;&nbsp;**3.5-skylake**-cc0.2.1&nbsp;&nbsp;**3.6-skylake**-cc0.2.1|

--- a/cultcargo/builder/cargo-manifest.yml
+++ b/cultcargo/builder/cargo-manifest.yml
@@ -63,7 +63,7 @@ images:
     versions:
       '1.3.4':
         package: aimfast==1.3.4
-      ## new master incoming so stay with 1.3.4
+      ## new master incoming so stay with 1.3.4 as latest version in cc0.2.1
       # master:
       #   package: git+https://github.com/Athanaseus/aimfast.git
 
@@ -192,17 +192,10 @@ images:
         package: crystalball  
 
   tricolour:
-    # versions:
-    #   # '0.1.8.1': 
-    #   #   dockerfile: Dockerfile.linked-image
-    #   #   link_older_image: tricolour:cc0.1.3
-    # will re-enable this when tricolour has numpy 2 under control again
-    #
     assign:
       default_python_version: '3.9'
     versions:
       master:
-        # pre_install: RUN pip install -U
         default_python_version: '3.10'
         package: git+https://github.com/ratt-ru/tricolour
       '0.1.8.2':
@@ -245,7 +238,7 @@ images:
         package: quartical==0.2.5
       latest:
         package: quartical
-      ## no master -- stop at 0.2.5 for cc0.2.1
+      ## no master -- let 0.2.5 be latest for cc0.2.1
       # master:
       #   default_python_version: '3.12'
       #   package: git+https://github.com/ratt-ru/QuartiCal
@@ -322,7 +315,7 @@ images:
     assign:
       CMD: spimple-spifit --help
     versions:
-      ## ModuleNotFoundError: No module named 'hip_cargo.callbacks'
+      ## ModuleNotFoundError: No module named 'hip_cargo.callbacks', so disabling master in 0.2.1
       # master:
       #   CMD: spimple --help
       #   package: git+https://github.com/landmanbester/spimple.git

--- a/cultcargo/builder/cargo-manifest.yml
+++ b/cultcargo/builder/cargo-manifest.yml
@@ -19,6 +19,7 @@ assign:
   extra_deps: ''
   default_pip_base_image: python-base
   default_python_version: '3.10'
+  pip_install_flags: ''
 
 images:
   # Bare-bones base images based off kern, with updates applied
@@ -57,11 +58,14 @@ images:
   # Package-specific images follow
 
   aimfast:
+    assign:
+      pip_install_flags: --no-build-isolation 
     versions:
       '1.3.4':
         package: aimfast==1.3.4
-      master:
-        package: git+https://github.com/Athanaseus/aimfast.git
+      ## new master incoming so stay with 1.3.4
+      # master:
+      #   package: git+https://github.com/Athanaseus/aimfast.git
 
   meqtrees:
     versions:
@@ -117,11 +121,11 @@ images:
       '3.6-skylake':
         package_version: 3.6
         target_cpu: skylake
-        kern_version: dev
+        kern_version: 10
         dockerfile: Dockerfile.build
       '3.6-haswell':
         package_version: 3.6
-        kern_version: dev
+        kern_version: 10
         dockerfile: Dockerfile.build
 
   casa:
@@ -168,13 +172,13 @@ images:
   shadems:
     versions:
       '0.5.3':
-        package: shadems==0.5.3
+        package: shadems==0.5.3 pyarrow dask[dataframe]\<2025.1
       '0.5.4':
-        package: shadems==0.5.4
+        package: shadems==0.5.4 pyarrow dask[dataframe]\<2025.1
       latest:
-        package: shadems
+        package: shadems pyarrow dask[dataframe]\<2025.1
       master:
-        package: git+https://github.com/ratt-ru/shadeMS
+        package: git+https://github.com/ratt-ru/shadeMS pyarrow dask[dataframe]\<2025.1
 
   crystalball:
     assign:
@@ -195,15 +199,16 @@ images:
     # will re-enable this when tricolour has numpy 2 under control again
     #
     assign:
-      default_python_version: '3.8'
+      default_python_version: '3.9'
     versions:
+      master:
+        # pre_install: RUN pip install -U
+        default_python_version: '3.10'
+        package: git+https://github.com/ratt-ru/tricolour
       '0.1.8.2':
         package: tricolour==0.1.8.2
       latest:
         package: tricolour
-      master:
-        # pre_install: RUN pip install -U
-        package: git+https://github.com/ratt-ru/tricolour
 
   smops:
     assign:
@@ -230,6 +235,7 @@ images:
   quartical:
     assign:
       CMD: goquartical
+      pip_install_flags: --no-build-isolation 
     versions:
       '0.2.3':
         package: quartical==0.2.3
@@ -237,12 +243,12 @@ images:
         package: quartical==0.2.4
       '0.2.5':
         package: quartical==0.2.5
-      '0.2.6dev':
-        package: git+https://github.com/ratt-ru/QuartiCal@v0.2.6-dev
       latest:
         package: quartical
-      master:
-        package: git+https://github.com/ratt-ru/QuartiCal
+      ## no master -- stop at 0.2.5 for cc0.2.1
+      # master:
+      #   default_python_version: '3.12'
+      #   package: git+https://github.com/ratt-ru/QuartiCal
 
   cubical:
     assign:
@@ -268,6 +274,7 @@ images:
       '0.0.5':
         package: pfb-imaging==0.0.5
       '0.0.6':
+        default_python_version: '3.11'
         package: pfb-imaging==0.0.6
       '0.0.7':
         package: pfb-imaging==0.0.7
@@ -315,8 +322,10 @@ images:
     assign:
       CMD: spimple-spifit --help
     versions:
-      master:
-        package: git+https://github.com/landmanbester/spimple.git
+      ## ModuleNotFoundError: No module named 'hip_cargo.callbacks'
+      # master:
+      #   CMD: spimple --help
+      #   package: git+https://github.com/landmanbester/spimple.git
       base:
         package: git+https://github.com/landmanbester/spimple.git@dropzweights
 
@@ -336,7 +345,7 @@ images:
 
   blri_pycorr:
     assign:
-      extra_deps: -U python-casacore pyuvdata
+      extra_deps: "-U python-casacore pyuvdata seticore@git+https://github.com/MydonSolutions/seticore.git#subdirectory=python"
     versions:
       master:
         package: git+https://github.com/MydonSolutions/BLRI.git@add-dedispersion

--- a/cultcargo/images/Dockerfile.generic.pip
+++ b/cultcargo/images/Dockerfile.generic.pip
@@ -3,7 +3,11 @@ FROM {REGISTRY}/{default_pip_base_image}:{default_python_version}-{BUNDLE_VERSIO
 {pre_install}
 
 RUN uv python pin python{default_python_version}
-RUN uv pip -n install --system {package} {extra_deps}
+
+# because 82 fucked us all
+RUN uv pip -n install --system setuptools\<82 
+
+RUN uv pip -n install --system {pip_install_flags} {package} {extra_deps}
 
 ## leaving old command for reference
 # RUN python{default_python_version} -m pip install --no-cache-dir {package} {extra_deps}

--- a/cultcargo/images/blri_pycorr/Dockerfile
+++ b/cultcargo/images/blri_pycorr/Dockerfile
@@ -1,14 +1,1 @@
-FROM {REGISTRY}/{default_pip_base_image}:{default_python_version}-{BUNDLE_VERSION}
-
-{pre_install}
-
-RUN uv pip install "seticore @ git+https://github.com/MydonSolutions/seticore.git#subdirectory=python"
-RUN uv python pin python{default_python_version}
-RUN uv pip -n install --system {package} {extra_deps}
-
-## leaving old command for reference
-# RUN python{default_python_version} -m pip install --no-cache-dir {package} {extra_deps}
-
-{post_install}
-
-CMD {CMD}
+../Dockerfile.generic.pip

--- a/cultcargo/images/meqtrees/Dockerfile.kern9
+++ b/cultcargo/images/meqtrees/Dockerfile.kern9
@@ -54,7 +54,7 @@ RUN mkdir /code/build && \
     rm -r /code/build &&  \
     ldconfig
 
-RUN pip install omegaconf stimela>=2.0
+RUN pip install omegaconf stimela>=2.0 astro-pyxis
 ADD . /meqConfs
 
 RUN python -c 'from Timba import mequtils'

--- a/cultcargo/images/wsclean/Dockerfile.build
+++ b/cultcargo/images/wsclean/Dockerfile.build
@@ -10,6 +10,9 @@ RUN apt-get update && apt-get -y upgrade && \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /var/cache/apt/archives 
 
+RUN mkdir -p /usr/share/casacore/data/
+RUN rsync -az rsync://casa-rsync.nrao.edu/casa-data /usr/share/casacore/data
+
 RUN git clone https://gitlab.com/aroffringa/wsclean.git && \
     (cd wsclean && git checkout v{package_version}) && \
     mkdir build && \
@@ -17,9 +20,6 @@ RUN git clone https://gitlab.com/aroffringa/wsclean.git && \
     ln -s /build/wsclean /usr/bin && \
     ln -s /build/chgcentre /usr/bin && \
     rm -fr /wsclean
-
-RUN mkdir -p /usr/share/casacore/data/
-RUN rsync -az rsync://casa-rsync.nrao.edu/casa-data /usr/share/casacore/data
 
 CMD ["wsclean"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 packages = [{include = "cultcargo"}]
 
 [tool.poetry.dependencies]
-python = ">=3.9 <=3.14"
+python = ">=3.9 <3.14"
 stimela = "^2.1.4"
 requests = "^2.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cult-cargo"
-version = "0.2.1rc6"
+version = "0.2.1"
 description = "Curated cargo of standard radio astronomy packages for stimela 2.x"
 authors = ["Oleg Smirnov, Sphesihle Makhathini"]
 license = "MIT"
@@ -8,8 +8,8 @@ readme = "README.md"
 packages = [{include = "cultcargo"}]
 
 [tool.poetry.dependencies]
-python = ">=3.9 <3.14"
-stimela = "^2.1.4rc2"
+python = ">=3.9 <=3.14"
+stimela = "^2.1.4"
 requests = "^2.0"
 
 [tool.poetry.scripts]


### PR DESCRIPTION
OK, I just got all the images to build again... felt like reassembling a delicate house of cards all over again (but mostly because setuptools 82 fucked everyone). Lesson is, no more endless release candidate cycles -- if it builds, ship it!

So, let's push 0.2.1 out the door finally as a checkpoint. This still relies on python3.10 as the baseline default in most images.

Meantime, I'm preparing 0.3.0, which will use python3.12 and depend on stimela and scabha >=2.2+. Will ship a release candidate shortly. Let us (me?) please release this one sooner than 18+ months later!